### PR TITLE
FIX: Auswahl des Streamservers auf verfügbare Server beschränkt

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="plugin.video.rtl_now" name="NOW" version="1.0.9" provider-name="AddonScriptorDE">
+<addon id="plugin.video.rtl_now" name="NOW" version="1.0.10" provider-name="AddonScriptorDE">
     <requires>
         <import addon="xbmc.python" version="2.1.0"/>
     </requires>

--- a/default.py
+++ b/default.py
@@ -280,7 +280,7 @@ def playVideo(urlMain):
                 playpath = "mp4:"+playpath
             finalUrl = "rtmpe://"+matchRTMPE[0][0]+"/"+matchRTMPE[0][1]+"/ playpath="+playpath+" swfVfy=1 swfUrl=http://"+hosterURL+"/includes/vodplayer.swf app="+matchRTMPE[0][1]+"/_definst_ tcUrl=rtmpe://"+matchRTMPE[0][0]+"/"+matchRTMPE[0][1]+"/ pageUrl="+urlMain
         elif matchHDS:
-            finalUrl = "rtmpe://fms-fra"+str(random.randint(1, 34))+".rtl.de/"+matchHDS[0][2]+"/ playpath=mp4:"+matchHDS[0][4].replace(".f4m", "")+" swfVfy=1 swfUrl=http://"+hosterURL+"/includes/vodplayer.swf app="+matchHDS[0][2]+"/_definst_ tcUrl=rtmpe://fms-fra"+str(random.randint(1, 34))+".rtl.de/"+matchHDS[0][2]+"/ pageUrl="+urlMain
+            finalUrl = "rtmpe://fms-fra"+str(random.randint(27, 33))+".rtl.de/"+matchHDS[0][2]+"/ playpath=mp4:"+matchHDS[0][4].replace(".f4m", "")+" swfVfy=1 swfUrl=http://"+hosterURL+"/includes/vodplayer.swf app="+matchHDS[0][2]+"/_definst_ tcUrl=rtmpe://fms-fra"+str(random.randint(27, 33))+".rtl.de/"+matchHDS[0][2]+"/ pageUrl="+urlMain
         if finalUrl:
             listitem = xbmcgui.ListItem(path=finalUrl)
             xbmcplugin.setResolvedUrl(pluginhandle, True, listitem)

--- a/default.py
+++ b/default.py
@@ -280,7 +280,21 @@ def playVideo(urlMain):
                 playpath = "mp4:"+playpath
             finalUrl = "rtmpe://"+matchRTMPE[0][0]+"/"+matchRTMPE[0][1]+"/ playpath="+playpath+" swfVfy=1 swfUrl=http://"+hosterURL+"/includes/vodplayer.swf app="+matchRTMPE[0][1]+"/_definst_ tcUrl=rtmpe://"+matchRTMPE[0][0]+"/"+matchRTMPE[0][1]+"/ pageUrl="+urlMain
         elif matchHDS:
-            finalUrl = "rtmpe://fms-fra"+str(random.randint(27, 33))+".rtl.de/"+matchHDS[0][2]+"/ playpath=mp4:"+matchHDS[0][4].replace(".f4m", "")+" swfVfy=1 swfUrl=http://"+hosterURL+"/includes/vodplayer.swf app="+matchHDS[0][2]+"/_definst_ tcUrl=rtmpe://fms-fra"+str(random.randint(27, 33))+".rtl.de/"+matchHDS[0][2]+"/ pageUrl="+urlMain
+            availableServers = (
+                "fms-fra21.rtl.de",
+                "fms-fra22.rtl.de",
+                "fms-fra23.rtl.de",
+                "fms-fra26.rtl.de",
+                "fms-fra27.rtl.de",
+                "fms-fra28.rtl.de",
+                "fms-fra32.rtl.de",
+                "fms-fra33.rtl.de",
+                )
+            selectedServer = random.choice(availableServers)
+            #comment this line if you DO NOT want to see the selected server!
+            xbmc.executebuiltin("XBMC.Notification(%s, %s, 3500, %s)" % ("Stream-Url", selectedServer, addon.getAddonInfo('icon')))
+
+            finalUrl = "rtmpe://"+selectedServer+"/"+matchHDS[0][2]+"/ playpath=mp4:"+matchHDS[0][4].replace(".f4m", "")+" swfVfy=1 swfUrl=http://"+hosterURL+"/includes/vodplayer.swf app="+matchHDS[0][2]+"/_definst_ tcUrl=rtmpe://"+selectedServer+"/"+matchHDS[0][2]+"/ pageUrl="+urlMain
         if finalUrl:
             listitem = xbmcgui.ListItem(path=finalUrl)
             xbmcplugin.setResolvedUrl(pluginhandle, True, listitem)


### PR DESCRIPTION
- behebt Problem der "TimeOuts" die sich in der 2 minutigen "Arbeitet..."-Meldung niederschlug
- Ursache war, dass der Streamserver per Zufall ausgewaehlt worden ist. Die Zufallswerte enthielten ungueltige / nicht laenger erreichbare Adressen (1-25 und 34)
